### PR TITLE
docs(readme): Fix usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ You can set this up [a few different ways](https://github.com/marionebl/commitli
 ```js
 {
   "commitlint": {
-    "extends": "commitlint-config-seek"
+    "extends": [
+      "seek"
+    ]
   }
 }
 ```


### PR DESCRIPTION
Took a bit of digging to figure out that you're not supposed to include the `commitlint-config-` prefix, otherwise it falls back to the legacy `conventional-changelog-lint-config-` prefix and throws an error when it's unable to find the package (in this case, it's looking for `conventional-changelog-lint-config-commitlint-config-seek` 😂)

Once I fixed this, I also discovered that the `extends` option must be an array, so I've cleaned that up too.

On the bright side, after fixing these two issues, the config worked perfectly 🎉 