### PR TITLE
fix(package): Use http-only repo url to support renovate

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/seek-oss/commitlint-config-seek.git"
+    "url": "https://github.com/seek-oss/commitlint-config-seek.git"
   },
   "author": "Seek",
   "license": "MIT",


### PR DESCRIPTION
Allows Renovate to cross link this repo in PRs and provide release notes to consumers